### PR TITLE
Bug Fix for ViewPropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": ">=0.46",
-    "lottie-react-native": ">=3.0.0"
+    "lottie-react-native": ">=3.0.0",
+    "deprecated-react-native-prop-types": "^2.3.0"
   },
   "author": "Vikrant Negi",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { StyleSheet, View, Modal, ViewPropTypes } from 'react-native';
+import { StyleSheet, View, Modal } from 'react-native';
 import PropTypes from 'prop-types';
 import LottieAnimation from 'lottie-react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 export default class AnimatedLoader extends React.PureComponent {
   static defaultProps = {


### PR DESCRIPTION
- Added 'deprecated-react-native-prop-types' package
- updated Import to use 'ViewPropTypes' from 'deprecated-react-native-prop-types'

As of one of expo SDK 46(?), ViewPropTypes is no longer available from the 'react-native' package. I was receiving a breaking error in my app because of 'ViewPropTypes'. 

For more info:
https://stackoverflow.com/questions/71702392/viewproptypes-will-be-removed-from-react-native-migrate-to-viewproptypes-export/73313120#73313120